### PR TITLE
Switch memo filenames to hyphenated dates

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Personal helper scripts for Zsh. The main script, `memo.sh`, provides handy comm
 
 ## memo.sh
 
-1. **memo [slug]**  – open today's note in `$EDITOR`. If you pass words, they become a suffix like `YYYYMMDD_slug.txt`.
+1. **memo [slug]**  – open today's note in `$EDITOR`. If you pass words, they become a suffix like `YYYY-MM-DD_slug.txt`.
 2. **ml** – open the memo directory in `$EDITOR`.
 3. **mg PATTERN** – search notes with `ripgrep`.
 4. **mr [N]** – show the first few lines from the N most recent notes (default: 7).

--- a/memo.sh
+++ b/memo.sh
@@ -2,7 +2,7 @@
 # memo.sh ─ Quick daily-note helpers
 #
 # Provides five convenience commands once sourced:
-#   memo        → open ~/memo/YYYYMMDD.txt (or YYYYMMDD_<slug>.txt) in $EDITOR
+#   memo        → open ~/memo/YYYY-MM-DD.txt (or YYYY-MM-DD_<slug>.txt) in $EDITOR
 #   ml          → open the ~/memo directory itself in $EDITOR
 #   mg PATTERN  → search every file in ~/memo with ripgrep (rg)
 #   mr [N]      → show the first few lines from the N most recent notes (default: 7)
@@ -27,7 +27,7 @@ _memo_open() {
 memo() {
   mkdir -p "$MEMO_DIR"                 # ensure the target directory exists
   local ymd
-  ymd="$(date +%Y%m%d)"                # today’s date, YYYYMMDD
+  ymd="$(date +%Y-%m-%d)"              # today’s date, YYYY-MM-DD
 
   if [ "$#" -eq 0 ]; then
     _memo_open "$MEMO_DIR/${ymd}.txt"


### PR DESCRIPTION
## Summary
- change memo date format to `YYYY-MM-DD`
- update README examples

## Testing
- `bash -n memo.sh`

------
https://chatgpt.com/codex/tasks/task_e_687ee8da2928833381ffddcbb16875ad